### PR TITLE
Fixed a segmentation fault error

### DIFF
--- a/NeuroSim.cpp
+++ b/NeuroSim.cpp
@@ -820,6 +820,7 @@ double NeuroSimSubArrayLeakagePower(SubArray *subArray) {
 			}
 		}
 	}
+	return 0;
 }
 
 // Neuron refers to the periphery circuit


### PR DESCRIPTION
Function NeuroSimSubArrayLeakagePower() was missing a return statement and as such, the program would crash with a segmentation fault while calculating the sub-array leakage power.

Steps to reproduce the error:

Pull source from master and unzip MNIST_data.zip
$ make
$ ./main
--Program crashes after a few seconds with:
  Segmentation fault (core dumped)
